### PR TITLE
Updated header image link

### DIFF
--- a/saved/page/templates/header.php
+++ b/saved/page/templates/header.php
@@ -1,5 +1,5 @@
 <!-- HEAD Start of header include -->
 <div id="header">
-    <img src="../public/resources/Header.png" alt="header-image" width="100%">
+    <img src="/resources/Header.png" alt="header-image" width="100%">
 </div>
 <!-- HEAD End of header include -->


### PR DESCRIPTION
The Link for the header image in the example files wont load the image for me, but changing the link to `/resources/Header.png` works.